### PR TITLE
fix texture applying on z- face

### DIFF
--- a/voxel_mesher/main.cpp
+++ b/voxel_mesher/main.cpp
@@ -131,7 +131,7 @@ public:
 			SetSetUV(uvRect.x, uvRect.height);
 			PushVertex(position, 0, 1, 0);
 
-			SetSetUV(uvRect.width, uvRect.y);
+			SetSetUV(uvRect.width, uvRect.height);
 			PushVertex(position, 1, 1, 0);
 		}
 		


### PR DESCRIPTION
When we apply a detailed texture on the voxels, we can notice that on the z- face it is not correctly applied.

Here is a picture to illustrate this :

![Screenshot from 2024-06-08 19-04-52](https://github.com/raylib-extras/examples-cpp/assets/62814224/6566a49f-cb2f-4748-ba5d-5d7823bc8488)
