### PR TITLE
Remove detached child from Children vector 

### DIFF
--- a/transform_hierarchy/main.cpp
+++ b/transform_hierarchy/main.cpp
@@ -32,6 +32,7 @@
 #include "object_transform.h"
 
 #include <vector>
+#include <iostream>
 #include <list>
 
 ObjectTransform PlayerBase;
@@ -67,6 +68,8 @@ void GameInit()
 	GunModel = LoadModel("resources/blasterD.glb");
 
 	OverlayTexture = LoadRenderTexture(GetScreenWidth(), GetScreenHeight());
+
+	
 }
 
 bool GameUpdate()
@@ -91,6 +94,9 @@ bool GameUpdate()
 
     if (IsKeyDown(KEY_D))
         PlayerBase.MoveH(GetFrameTime() * -10);
+
+	if (IsKeyPressed(KEY_SPACE))
+		GunNode.Detach();
 
 	return true;
 }

--- a/transform_hierarchy/object_transform.h
+++ b/transform_hierarchy/object_transform.h
@@ -49,6 +49,29 @@ private:
     ObjectTransform* Parent = nullptr;
     std::vector<ObjectTransform*> Children;
 
+    inline ObjectTransform* RemoveChild(ObjectTransform* child)
+    {
+        // if the node has no children, return a null pointer
+        if (Children.empty())
+        {
+            return nullptr;
+        }
+
+        // find the child's position in the children list
+        auto childIter = std::find(Children.begin(), Children.end(), child);
+
+        // if the children list doesn't contain the child, return a nullptr
+        if (childIter == Children.end())
+        {
+            return nullptr;
+        }
+
+        // remove the child
+        Children.erase(childIter);
+
+        return child;
+    }
+
 public:
 
     ObjectTransform(bool faceY = true)
@@ -95,29 +118,6 @@ public:
             Parent->Children.push_back(this);
     }
 
-    inline ObjectTransform* RemoveChild(ObjectTransform* child)
-    {
-        // if the node has no children, return a null pointer
-        if (Children.empty())
-        {
-            return nullptr;
-        }
-
-        // find the child's position in the children list
-        auto childIter = std::find(Children.begin(), Children.end(), child);
-        
-        // if the children list doesn't contain the child, return a nullptr
-        if (childIter == Children.end())
-        {
-            return nullptr;
-        }
-
-        // remove the child
-        Children.erase(childIter);
-
-        return child;
-    }
-
     inline void Detach()
     {
         if (!GetParent())
@@ -130,6 +130,8 @@ public:
         Matrix orientationMatrix = MatrixMultiply(worldTransform, translateMatrix);
 
         Orientation = QuaternionFromMatrix(WorldMatrix);
+
+        GetParent()->RemoveChild(this);
 
         Reparent(nullptr);
     }

--- a/transform_hierarchy/object_transform.h
+++ b/transform_hierarchy/object_transform.h
@@ -95,6 +95,29 @@ public:
             Parent->Children.push_back(this);
     }
 
+    inline ObjectTransform* RemoveChild(ObjectTransform* child)
+    {
+        // if the node has no children, return a null pointer
+        if (Children.empty())
+        {
+            return nullptr;
+        }
+
+        // find the child's position in the children list
+        auto childIter = std::find(Children.begin(), Children.end(), child);
+        
+        // if the children list doesn't contain the child, return a nullptr
+        if (childIter == Children.end())
+        {
+            return nullptr;
+        }
+
+        // remove the child
+        Children.erase(childIter);
+
+        return child;
+    }
+
     inline void Detach()
     {
         if (!GetParent())


### PR DESCRIPTION
Added the `RemoveChild` method to the `ObjectTransform` class so that when a child node detaches from its parent, the child is removed from the parent's `Children` vector as well.

Also added an example in `main.cpp`.